### PR TITLE
Remove the unnecessary dependency package

### DIFF
--- a/icart_mini_ros_pkgs.install
+++ b/icart_mini_ros_pkgs.install
@@ -23,7 +23,3 @@
     local-name: ros_controllers
     version: indigo-devel
 
-- git:
-    uri: https://github.com/yujinrobot/navigation
-    local-name: navigation
-    version: 0ad55d3799e3ac4f988f5190632a71a080b39a65


### PR DESCRIPTION
ROSのNavigationの[バグ](https://github.com/ros-planning/navigation/pull/254)が修正されたものがdebパッケージ化されたのでrosinstallのリストから削除
