### PR TITLE
Fixed 70-sensors.rules to accommodate a plurality of devices connected.

### DIFF
--- a/70-sensors.rules
+++ b/70-sensors.rules
@@ -1,3 +1,3 @@
-SUBSYSTEMS=="usb", KERNEL=="ttyACM*", ACTION=="add", ATTRS{product}=="URG-Series USB Driver", MODE="666", SYMLINK+="sensors/hokuyo_urg" GROUP="dialout"
+SUBSYSTEMS=="usb", KERNEL=="ttyACM*", ACTION=="add", ATTRS{product}=="URG-Series USB Driver", MODE="666", SYMLINK+="sensors/hokuyo_urg%n" GROUP="dialout"
 SUBSYSTEMS=="usb", KERNEL=="ttyACM*", ACTION=="add", ATTRS{product}=="T-frog Driver", MODE="666", SYMLINK+="sensors/icart-mini", GROUP="dialout"
-SUBSYSTEMS=="usb", KERNEL=="ttyUSB*", ACTION=="add", ATTRS{product}=="FT232R USB UART", MODE="666", SYMLINK+="sensors/imu", GROUP="dialout"
+SUBSYSTEMS=="usb", KERNEL=="ttyUSB*", ACTION=="add", ATTRS{product}=="FT232R USB UART", MODE="666", SYMLINK+="sensors/ftdi%n", GROUP="dialout"

--- a/70-sensors.rules
+++ b/70-sensors.rules
@@ -1,3 +1,3 @@
-SUBSYSTEMS=="usb", KERNEL=="ttyACM*", ACTION=="add", ATTRS{product}=="URG-Series USB Driver", MODE="666", SYMLINK+="sensors/hokuyo_urg%n" GROUP="dialout"
+SUBSYSTEMS=="usb", KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="15d1", ATTRS{idProduct}=="0000", MODE="666", PROGRAM="/opt/ros/indigo/env.sh rosrun hokyuo_node getID %N q", SYMLINK+="sensors/hokuyo_%c", GROUP="dialout"
 SUBSYSTEMS=="usb", KERNEL=="ttyACM*", ACTION=="add", ATTRS{product}=="T-frog Driver", MODE="666", SYMLINK+="sensors/icart-mini", GROUP="dialout"
 SUBSYSTEMS=="usb", KERNEL=="ttyUSB*", ACTION=="add", ATTRS{product}=="FT232R USB UART", MODE="666", SYMLINK+="sensors/ftdi%n", GROUP="dialout"


### PR DESCRIPTION
URGやFtdiのデバイスを複数接続した時に、/dev/sensors以下に番号付きでデバイス名が指定されるようにした
