### PR TITLE
amclのパラメータの調整

### DIFF
--- a/orne_navigation_executor/launch/localization.launch
+++ b/orne_navigation_executor/launch/localization.launch
@@ -16,8 +16,8 @@
   <param name="odom_alpha2" value="0.2"/>
   <!-- translation std dev, m -->
   <param name="odom_alpha3" value="0.8"/>
-  <param name="odom_alpha4" value="0.2"/>
-  <param name="laser_z_hit" value="0.5"/>
+  <param name="odom_alpha4" value="0.1"/>
+  <param name="laser_z_hit" value="0.45"/>
   <param name="laser_z_short" value="0.05"/>
   <param name="laser_z_max" value="0.05"/>
   <param name="laser_z_rand" value="0.5"/>


### PR DESCRIPTION
トライアル区間においてランドマークが少ない領域に突入したさいパーティクルが発散し，コースアウトしてしまった．このような問題に対してamclのパラメータを変更し，対応した．具体的にはサンプリング(オドメトリ動作モデル)における誤差パラメータのalpha_4と，重み付け(尤度場モデル)のパラメータのz_hitを変更．学内においては，自律移動が可能なことを確認．

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/118)

<!-- Reviewable:end -->
