### PR TITLE
modified to use eth_urg instead of hokuyo_urg

### DIFF
--- a/orne_bringup/launch/orne_alpha.launch
+++ b/orne_bringup/launch/orne_alpha.launch
@@ -1,7 +1,7 @@
 <launch>
     <include file="$(find icart_mini_driver)/launch/icart_mini_drive.launch">
         <arg name="model"    value="$(find xacro)/xacro.py '$(find orne_description)/urdf/orne_alpha.xacro'"/>
-        <arg name="use_eth_urg" value="true"/>
+        <arg name="scan_dev" value="/dev/sensors/hokuyo"/>
     </include>
 
     <node pkg="cit_adis_imu" type="imu_node" name="imu_node">


### PR DESCRIPTION
現在ORNEαはEthernetのURGではなく，USBのURGを使用しているため，それに合わせてlaunchファイルを変更．

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/167)

<!-- Reviewable:end -->
