### PR TITLE
fix 70-sensors.rules

### DIFF
--- a/orne_bringup/launch/orne_beta.launch
+++ b/orne_bringup/launch/orne_beta.launch
@@ -6,7 +6,7 @@
 
     <node pkg="cit_adis_imu" type="imu_node" name="imu_node">
         <remap from="imu"        to="imu_data"/>
-        <param name="port_name"  value="/dev/sensors/ftdi0"/>
+        <param name="port_name"  value="/dev/sensors/imu"/>
         <param name="z_axis_dir" value="-1"/>
     </node>
 

--- a/orne_setup/config/70-sensors.rules
+++ b/orne_setup/config/70-sensors.rules
@@ -1,3 +1,3 @@
 SUBSYSTEMS=="usb", KERNEL=="ttyACM[0-9]*", ACTION=="add", ATTRS{idVendor}=="15d1", ATTRS{idProduct}=="0000", MODE="666", PROGRAM="/opt/ros/indigo/env.sh rosrun hokyuo_node getID %N q", SYMLINK+="sensors/hokuyo_%c", GROUP="dialout"
 SUBSYSTEMS=="usb", KERNEL=="ttyACM*", ACTION=="add", ATTRS{product}=="T-frog Driver", MODE="666", SYMLINK+="sensors/icart-mini", GROUP="dialout"
-SUBSYSTEMS=="usb", KERNEL=="ttyUSB*", ACTION=="add", ATTRS{product}=="FT232R USB UART", MODE="666", SYMLINK+="sensors/ftdi%n", GROUP="dialout"
+SUBSYSTEMS=="usb", KERNEL=="ttyUSB*", ACTION=="add", ATTRS{product}=="FT232R USB UART", MODE="666", SYMLINK+="sensors/imu", GROUP="dialout"


### PR DESCRIPTION
orneαとorneβのudev ruleがハードウェア等の構成の違いから，それぞれ異なっている必要があった，現在はその必要がなく，create_udev_rulesを実行した際にそれらに対応できないので，udev_ruleを統一した．

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/171)

<!-- Reviewable:end -->
