### PR TITLE
自律移動時の速度の変更

### DIFF
--- a/orne_navigation_executor/param/base_local_planner_params_alpha.yaml
+++ b/orne_navigation_executor/param/base_local_planner_params_alpha.yaml
@@ -1,6 +1,6 @@
 TrajectoryPlannerROS:
   holonomic_robot: false
-  max_vel_x: 0.4
+  max_vel_x: 0.6
   min_vel_x: -0.4
   max_vel_y: 0.0
   min_vel_y: 0.0


### PR DESCRIPTION
今までのαの自律移動時の速度が遅かったため、早くした

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/282)
<!-- Reviewable:end -->
