### PR TITLE
インストール直後、αが起動ができないバグの修正

### DIFF
--- a/orne_bringup/launch/orne_alpha_sim.launch
+++ b/orne_bringup/launch/orne_alpha_sim.launch
@@ -1,8 +1,8 @@
 <launch>
     <include file="$(find icart_mini_gazebo)/launch/icart_mini.launch">
         <arg name="model" value="$(find xacro)/xacro.py '$(find orne_description)/urdf/orne_alpha_sim.xacro'"/>
-        <arg name="world" value="$(find icart_mini_gazebo)/worlds/willow.world"/>
-    </include>
+    	<arg name="world" value="$(find icart_mini_gazebo)/worlds/willow.world"/>
+	</include>
 
     <include file="$(find orne_bringup)/launch/includes/base.launch.xml"/>
 </launch>

--- a/orne_description/urdf/orne_alpha.xacro
+++ b/orne_description/urdf/orne_alpha.xacro
@@ -9,7 +9,6 @@
 <xacro:include filename="$(find orne_description)/urdf/orne_x.xacro"/>
 <xacro:include filename="$(find icart_mini_description)/urdf/sensors/imu.urdf.xacro"/>
 <xacro:include filename="$(find icart_mini_description)/urdf/sensors/hokuyo.urdf.xacro"/>
-<xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/>
 
 <!-- Setting for imu -->
 <xacro:sensor_imu name="imu" parent="base_link" size="0.05 0.05 0.05">
@@ -39,7 +38,9 @@
 </xacro:sensor_hokuyo3d>
 -->
 
-<xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/>
+<!--$acro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/-->
+<xacro:include filename="$(find orne_description)/urdf/sensors/vlp16.urdf.xacro"/>
+
 <xacro:VLP-16 name="velodyne" parent="base_link">
     <origin xyz="0.098 0.0 0.422" rpy="0 0 -0.12"/>
 </xacro:VLP-16>

--- a/orne_description/urdf/orne_alpha_sim.xacro
+++ b/orne_description/urdf/orne_alpha_sim.xacro
@@ -8,9 +8,6 @@
 
 <xacro:include filename="$(find orne_description)/urdf/orne_x.xacro"/>
 <xacro:include filename="$(find icart_mini_description)/urdf/sensors/imu.urdf.xacro"/>
-<xacro:include filename="$(find icart_mini_description)/urdf/sensors/hokuyo.urdf.xacro"/>
-<xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/>
-
 <!-- Setting for imu -->
 <xacro:sensor_imu name="imu" parent="base_link" size="0.05 0.05 0.05">
     <origin xyz="-0.145 0.0 0.21" rpy="0 0 0"/>
@@ -19,6 +16,7 @@
 
 
 <!-- Setting for levelly fixed 2D URG -->
+<xacro:include filename="$(find icart_mini_description)/urdf/sensors/hokuyo.urdf.xacro"/>
 <xacro:sensor_hokuyo name="hokuyo" parent="base_link">
     <origin xyz="0.212 0 0.2485" rpy="0 0 0"/>
 </xacro:sensor_hokuyo>
@@ -39,11 +37,13 @@
 </xacro:sensor_hokuyo3d>
 -->
 
-
-
-<xacro:include filename="$(find velodyne_description)/urdf/VLP-16.urdf.xacro"/>
-<xacro:VLP-16 name="velodyne" parent="base_link">
+<xacro:include filename="$(find orne_description)/urdf/sensors/vlp16.urdf.xacro"/>
+<xacro:vlp16_2d name="velodyne" parent="base_link">
     <origin xyz="0.098 0.0 0.422" rpy="0 0 0"/>
-</xacro:VLP-16>
+</xacro:vlp16_2d>
+<xacro:vlp16_3d name="velodyne3d" parent="base_link">
+    <origin xyz="0.098 0.0 0.422" rpy="0 0 0"/>
+</xacro:vlp16_3d>
+
 
 </robot>

--- a/orne_description/urdf/orne_x.xacro
+++ b/orne_description/urdf/orne_x.xacro
@@ -28,14 +28,14 @@
     <collision>
       <origin xyz="0.005 0 0.305" rpy="0 0 0"/>
       <geometry>
-	       <box size=".376 .45 .242"/>
+	       <box size=".376 .45 .134"/>
       </geometry>
     </collision>
 
     <visual>
       <origin xyz="0.005 0 0.305" rpy="0 0 0"/>
       <geometry>
-	       <box size=".376 .45 .242"/>
+	       <box size=".376 .45 .134"/>
       </geometry>
       <material name="orange"/>
     </visual>

--- a/orne_description/urdf/sensors/vlp16.urdf.xacro
+++ b/orne_description/urdf/sensors/vlp16.urdf.xacro
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<robot name="vlp16" xmlns:xacro="http://ros.org/wiki/xacro"
+                              xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller"
+                              xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
+
+  <xacro:macro name="VLP-16" params="name parent *origin">
+      <joint name="${name}_joint" type="fixed">
+          <axis xyz="1 0 0"/>
+          <insert_block name="origin"/>
+          <parent link="${parent}"/>
+          <child link="${name}"/>
+      </joint>
+
+      <link name="${name}">
+          <inertial>
+            <mass value="0.001"/>
+            <origin rpy="0 0 0" xyz="0 0 0"/>
+            <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.0001"/>
+          </inertial>
+          <visual>
+            <origin rpy="0 0 0.1" xyz="0 0 0"/>
+            <geometry>
+              <box size="0.1 0.1 0.1"/>
+            </geometry>
+          </visual>
+          <collision>
+            <origin rpy="0 0 0.1" xyz="0 0 0"/>
+            <geometry>
+              <box size="0.1 0.1 0.1"/>
+            </geometry>
+          </collision>
+      </link>
+  </xacro:macro>
+
+  <xacro:macro name="vlp16_2d" params="name parent *origin">
+	  <joint name="${name}_joint" type="fixed">
+	      <axis xyz="1 0 0"/>
+	      <insert_block name="origin"/>
+	      <parent link="${parent}"/>
+	      <child link="${name}"/>
+	  </joint>
+
+	  <link name="${name}">
+	      <inertial>
+	        <mass value="0.001"/>
+	        <origin rpy="0 0 0" xyz="0 0 0"/>
+	        <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.0001"/>
+	      </inertial>
+	      <visual>
+	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
+	        <geometry>
+	          <box size="0.1 0.1 0.1"/>
+	        </geometry>
+	      </visual>
+	      <collision>
+	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
+	        <geometry>
+	          <box size="0.1 0.1 0.1"/>
+	        </geometry>
+	      </collision>
+	  </link>
+
+      <gazebo reference="${name}">
+        <sensor name="velodyne_2d" type="ray">
+        <always_on>true</always_on>
+        <visualize>false</visualize>
+        <update_rate>10</update_rate>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>720</samples>
+              <resolution>1.0</resolution>
+              <min_angle>-3.141592</min_angle>
+              <max_angle>3.141592</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>0.90</min>
+            <max>100.0</max>
+            <resolution>0.01</resolution>
+          </range>
+        </ray>
+        <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_laser.so">
+            <topicName>/vel_scan</topicName>
+            <frameName>${name}</frameName>
+        </plugin>
+      </sensor>
+    </gazebo>
+  </xacro:macro>
+
+
+  <xacro:macro name="vlp16_3d" params="name parent *origin">
+	  <joint name="${name}_joint" type="fixed">
+	      <axis xyz="1 0 0"/>
+	      <insert_block name="origin"/>
+	      <parent link="${parent}"/>
+	      <child link="${name}"/>
+	  </joint>
+
+	  <link name="${name}">
+	      <inertial>
+	        <mass value="0.001"/>
+	        <origin rpy="0 0 0" xyz="0 0 0"/>
+	        <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.0001"/>
+	      </inertial>
+	      <visual>
+	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
+	        <geometry>
+	          <box size="0.1 0.1 0.1"/>
+	        </geometry>
+	      </visual>
+	      <collision>
+	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
+	        <geometry>
+	          <box size="0.1 0.1 0.1"/>
+	        </geometry>
+	      </collision>
+	  </link>
+    <gazebo reference="${name}">
+      <sensor name="velodyne_3d" type="ray">
+      <always_on>true</always_on>
+      <visualize>false</visualize>
+      <update_rate>5</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <samples>145</samples>
+            <resolution>1.0</resolution>
+            <min_angle>-3.141592</min_angle>
+            <max_angle>3.141592</max_angle>
+          </horizontal>
+          <vertical>
+            <samples>16</samples>
+            <resolution>1.0</resolution>
+            <min_angle>-0.0872664626</min_angle>
+            <max_angle>0.610865238</max_angle>
+          </vertical>
+        </scan>
+        <range>
+          <min>0.90</min>
+          <max>100.0</max>
+          <resolution>0.01</resolution>
+        </range>
+      </ray>
+      <plugin name="ros_hokuyo3d" filename="libgazebo_ros_block_laser.so">
+        <gaussianNoise>0.02</gaussianNoise>
+        <updateRate>20</updateRate>
+        <topicName>/${name}_cloud</topicName>
+        <frameName>${name}</frameName>
+      </plugin>
+    </sensor>
+  </gazebo>
+  </xacro:macro>
+</robot>

--- a/orne_description/urdf/sensors/vlp16.urdf.xacro
+++ b/orne_description/urdf/sensors/vlp16.urdf.xacro
@@ -33,32 +33,32 @@
   </xacro:macro>
 
   <xacro:macro name="vlp16_2d" params="name parent *origin">
-	  <joint name="${name}_joint" type="fixed">
-	      <axis xyz="1 0 0"/>
-	      <insert_block name="origin"/>
-	      <parent link="${parent}"/>
-	      <child link="${name}"/>
-	  </joint>
+    <joint name="${name}_joint" type="fixed">
+        <axis xyz="1 0 0"/>
+        <insert_block name="origin"/>
+        <parent link="${parent}"/>
+        <child link="${name}"/>
+    </joint>
 
-	  <link name="${name}">
-	      <inertial>
-	        <mass value="0.001"/>
-	        <origin rpy="0 0 0" xyz="0 0 0"/>
-	        <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.0001"/>
-	      </inertial>
-	      <visual>
-	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
-	        <geometry>
-	          <box size="0.1 0.1 0.1"/>
-	        </geometry>
-	      </visual>
-	      <collision>
-	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
-	        <geometry>
-	          <box size="0.1 0.1 0.1"/>
-	        </geometry>
-	      </collision>
-	  </link>
+    <link name="${name}">
+        <inertial>
+          <mass value="0.001"/>
+          <origin rpy="0 0 0" xyz="0 0 0"/>
+          <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.0001"/>
+        </inertial>
+        <visual>
+          <origin rpy="0 0 0.1" xyz="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </visual>
+        <collision>
+          <origin rpy="0 0 0.1" xyz="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </collision>
+    </link>
 
       <gazebo reference="${name}">
         <sensor name="velodyne_2d" type="ray">
@@ -75,7 +75,7 @@
             </horizontal>
           </scan>
           <range>
-            <min>0.90</min>
+            <min>0.10</min>
             <max>100.0</max>
             <resolution>0.01</resolution>
           </range>
@@ -95,32 +95,32 @@
 
 
   <xacro:macro name="vlp16_3d" params="name parent *origin">
-	  <joint name="${name}_joint" type="fixed">
-	      <axis xyz="1 0 0"/>
-	      <insert_block name="origin"/>
-	      <parent link="${parent}"/>
-	      <child link="${name}"/>
-	  </joint>
+    <joint name="${name}_joint" type="fixed">
+        <axis xyz="1 0 0"/>
+        <insert_block name="origin"/>
+        <parent link="${parent}"/>
+        <child link="${name}"/>
+    </joint>
 
-	  <link name="${name}">
-	      <inertial>
-	        <mass value="0.001"/>
-	        <origin rpy="0 0 0" xyz="0 0 0"/>
-	        <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.0001"/>
-	      </inertial>
-	      <visual>
-	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
-	        <geometry>
-	          <box size="0.1 0.1 0.1"/>
-	        </geometry>
-	      </visual>
-	      <collision>
-	        <origin rpy="0 0 0.1" xyz="0 0 0"/>
-	        <geometry>
-	          <box size="0.1 0.1 0.1"/>
-	        </geometry>
-	      </collision>
-	  </link>
+    <link name="${name}">
+        <inertial>
+          <mass value="0.001"/>
+          <origin rpy="0 0 0" xyz="0 0 0"/>
+        <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.0001"/>
+        </inertial>
+        <visual>
+          <origin rpy="0 0 0.1" xyz="0 0 0"/>
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry>
+       </visual>
+       <collision>
+          <origin rpy="0 0 0.1" xyz="0 0 0"/> 
+          <geometry>
+            <box size="0.1 0.1 0.1"/>
+          </geometry> 
+        </collision>
+    </link>
     <gazebo reference="${name}">
       <sensor name="velodyne_3d" type="ray">
       <always_on>true</always_on>
@@ -129,7 +129,7 @@
       <ray>
         <scan>
           <horizontal>
-            <samples>145</samples>
+            <samples>1825</samples>
             <resolution>1.0</resolution>
             <min_angle>-3.141592</min_angle>
             <max_angle>3.141592</max_angle>
@@ -137,12 +137,12 @@
           <vertical>
             <samples>16</samples>
             <resolution>1.0</resolution>
-            <min_angle>-0.0872664626</min_angle>
-            <max_angle>0.610865238</max_angle>
+            <min_angle>-0.2617993875</min_angle>
+            <max_angle>0.2617993875</max_angle>
           </vertical>
         </scan>
         <range>
-          <min>0.90</min>
+          <min>0.10</min>
           <max>100.0</max>
           <resolution>0.01</resolution>
         </range>


### PR DESCRIPTION
デフォルトのインストールではvelodyne_descriprition が存在しないためαが起動できない問題があった

そのため、orneのパッケージにvelodyne用のファイルを追加した

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/390)
<!-- Reviewable:end -->
