### PR TITLE
fix variable's name to run function of setting waypoints on simulator…

### DIFF
--- a/orne_rviz_plugins/src/state_trigger_panel.cpp
+++ b/orne_rviz_plugins/src/state_trigger_panel.cpp
@@ -18,7 +18,7 @@ namespace orne_rviz_plugins
 StateTriggerPanel::StateTriggerPanel( QWidget* parent )
   : rviz::Panel( parent )
 {
-  start_client_ = nh_.serviceClient<std_srvs::Trigger>("start_nav", false);
+  start_client_ = nh_.serviceClient<std_srvs::Trigger>("start_wp_nav", false);
   resume_client_ = nh_.serviceClient<std_srvs::Trigger>("resume_nav", false);
 
   start_nav_button_ = new QPushButton("StartWaypointsNavigation");


### PR DESCRIPTION
シミュレーター上にてwaypointが配置できない問題
21行目の第1引数
"start_nav" → "start_wp_nav"
に変更

fulanghua_navigation/fulanghua_waypoints_nav/src/waypoints_nav.cpp の106行目を参照

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/431)
<!-- Reviewable:end -->
