### PR TITLE
add inf_is_valid

### DIFF
--- a/orne_navigation_executor/param/costmap_common_params.yaml
+++ b/orne_navigation_executor/param/costmap_common_params.yaml
@@ -10,6 +10,6 @@ resolution: 0.15
 
 observation_sources: scan point_cloud
 
-scan: {data_type: LaserScan, topic: /scan, marking: true, clearing: true, min_obstacle_height: 0.15, max_obstacle_height: 1.0}
+scan: {data_type: LaserScan, topic: /scan, marking: true, clearing: true, inf_is_valid: true, min_obstacle_height: 0.15, max_obstacle_height: 1.0}
 
-point_cloud: {data_type: PointCloud, topic: /filtered_cloud, marking: true, clearing: true}
+point_cloud: {data_type: PointCloud, topic: /filtered_cloud, marking: true, clearing: true, inf_is_valid: true}


### PR DESCRIPTION
開けた場所でコストが残る現象をなくす変更です。
従来はレーザレンジセンサで何も検出されないと、そのままコストを残すという処理がされていました。
シミュレータで検証しようと思いましたが、シミュレータ自身が林原の環境では動作しないようです。
gazeboが起動しません。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/442)
<!-- Reviewable:end -->
