### PR TITLE
change caster friction

### DIFF
--- a/orne_description/urdf/orne_x.gazebo
+++ b/orne_description/urdf/orne_x.gazebo
@@ -23,6 +23,8 @@
   <!-- Base Link -->
   <gazebo reference="base_link">
     <material>Gazebo/White</material>
+    <mu1>0.1</mu1>
+    <mu2>0.1</mu2>
   </gazebo>
 
   <!-- Right Wheel -->


### PR DESCRIPTION
orne_alphaがgazeboで曲がらないときに摩擦の影響かと考えて，キャスタの摩擦を下げたので，そのログを残しておく．

ロボットの挙動から，以下の要因が大きかったが，摩擦の影響も少しはあったように思えるので，念のためログを残しておく．
https://github.com/open-rdc/orne_navigation/pull/508#discussion_r551715092

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-rdc/orne_navigation/520)
<!-- Reviewable:end -->
